### PR TITLE
update package name for pl_bolts

### DIFF
--- a/unit06-dl-tips/exercises/1_cosine-with-warmup/README.md
+++ b/unit06-dl-tips/exercises/1_cosine-with-warmup/README.md
@@ -12,7 +12,7 @@ In particular, your task is to replace the `torch.optim.lr_scheduler.CosineAnnea
  `LinearWarmupCosineAnnealingLR` class from the PyTorch Lightning Bolts library, which can be installed via 
 
 
-    pip install pl-bolts
+    pip install lightning-bolts
 
 And you can find more about the `LinearWarmupCosineAnnealingLR` usage in the [documentation here](https://pytorch-lightning-bolts.readthedocs.io/en/latest/schedulers/warmup_cosine_annealing.html)
 


### PR DESCRIPTION
It looks like "pl-bolts" no longer exists (I got the following error message when tried to install pl-bolts)

ERROR: Could not find a version that satisfies the requirement pl-bolts (from versions: none)
ERROR: No matching distribution found for pl-bolts 

Switching to "lightning-bolts" solved the problem.